### PR TITLE
feat(linux): Make this module Windows only

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,8 @@
-module.exports = require("bindings")({
+if (process.platform !== "win32") {
+  module.exports = { getPIDByName: () => -1, injectPID: () => -1 };
+} else {
+  module.exports = require("bindings")({
     bindings: "injector.node",
     module_root: __dirname,
-});
+  });
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "author": "Supamiu",
   "license": "MIT",
+  "os": ["win32"],
   "gypfile": "true",
   "binary": {
     "napi_versions": [


### PR DESCRIPTION
This is a protection so if the module is imported in Linux, it won't attempt to load or build.